### PR TITLE
132 running wrapup without git credentials configures results in an incorrect error message

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -39,6 +39,9 @@ func ExecuteCommand(command string, argv ...string) (string, error) {
 	}
 
 	if err := exe.Wait(); err != nil {
+		if out := stdOutBuffer.String(); stdErrBuffer.String() == "" {
+			return "", errors.New(out)
+		}
 		return "", errors.New(stdErrBuffer.String())
 	}
 

--- a/phlow/deliver.go
+++ b/phlow/deliver.go
@@ -45,7 +45,6 @@ func Deliver(defaultBranch string) {
 		return
 	}
 
-	ui.PhlowSpinner.Stop()
 	fmt.Printf("Delivered branch %s \n", ui.Format.Branch(branchInfo.Current))
 }
 
@@ -90,7 +89,7 @@ func LocalDeliver(defaultBranch string) {
 		fmt.Println(err.Error())
 		return
 	}
-	ui.PhlowSpinner.Stop()
+
 	fmt.Printf("Delivered changes from %s to %s \n", ui.Format.Branch(branchInfo.Current), ui.Format.Branch(defaultBranch))
 }
 

--- a/phlow/workon.go
+++ b/phlow/workon.go
@@ -14,6 +14,7 @@ import (
 //WorkOn ...
 func WorkOn(issue int) {
 	ui.PhlowSpinner.Start("Setting up workspace")
+
 	defer ui.PhlowSpinner.Stop()
 	if err := githandler.Fetch(); err != nil {
 		fmt.Println(err)
@@ -70,7 +71,7 @@ func WorkOn(issue int) {
 			return
 		}
 	}
-	ui.PhlowSpinner.Stop()
+
 	fmt.Println("No matching issues")
 }
 

--- a/phlow/wrapup.go
+++ b/phlow/wrapup.go
@@ -30,7 +30,7 @@ func WrapUp() {
 	}
 
 	if _, err := githandler.Commit(cmsg); err != nil {
-		fmt.Println("Nothing to commit!")
+		fmt.Println(err)
 		return
 	}
 	fmt.Fprintln(os.Stdout, cmsg)


### PR DESCRIPTION
I'm sorry for the cleanup that comes with this PR. 
It was a small thing, so I hope it's OK. 

I've chosen to just print the error to show the actual git message.
The reason the error didn't show up, is that the git message coming from wrapup is not an actual error, but just an ordinary message. 